### PR TITLE
Update upstream AnvilGUI to make compatible with MC 1.21.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,132 @@
+### Java template
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+### Maven template
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# Eclipse m2e generated files
+# Eclipse Core
+.project
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# AWS User-specific
+.idea/**/aws.xml
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+/MilkGUI.iml
+/.idea/checkstyle-idea.xml
+/.idea/copilot.data.migration.ask2agent.xml
+/.idea/discord.xml
+/.idea/encodings.xml
+/.idea/google-java-format.xml
+/.idea/misc.xml
+/.idea/vcs.xml

--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ fabric.properties
 /.idea/google-java-format.xml
 /.idea/misc.xml
 /.idea/vcs.xml
+/.idea/git_toolbox_prj.xml

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.browsit</groupId>
+    <groupId>com.voxelforged</groupId>
     <artifactId>MilkGUI</artifactId>
     <version>4.0.4</version>
 
     <licenses>
         <license>
             <name>MIT License</name>
-            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <url>https://www.opensource.org/licenses/mit-license.php</url>
         </license>
     </licenses>
 
@@ -31,9 +31,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.13.2-R0.1-SNAPSHOT</version>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot-api</artifactId>
+            <version>1.20.6-R0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,6 +6,17 @@
     <groupId>com.voxelforged</groupId>
     <artifactId>MilkGUI</artifactId>
     <version>4.0.4</version>
+    <packaging>jar</packaging>
+
+    <name>${project.groupId}:${project.artifactId}</name>
+    <description>MilkGUI is an easy-to-use, modern GUI library for Spigot plugins.</description>
+    <url>https://gitlab.com/VoxelForged/milkgui</url>
+
+    <scm>
+        <connection>scm:git:git@gitlab.com:voxelforged/MilkGUI.git</connection>
+        <developerConnection>scm:git:git@gitlab.com:voxelforged/MilkGUI.git</developerConnection>
+        <url>https://gitlab.com/VoxelForged/milkgui</url>
+    </scm>
 
     <developers>
         <developer>
@@ -46,12 +57,12 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.6-R0.1-SNAPSHOT</version>
+            <version>1.20.6-R0.1-20240613.150924-57</version>
         </dependency>
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui</artifactId>
-            <version>1.10.11-SNAPSHOT</version>
+            <version>1.10.11-20251225.065250-1</version>
         </dependency>
     </dependencies>
 
@@ -76,33 +87,56 @@
         </resources>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.5.3</version>
-                <!-- Do not include the <configuration>...</configuration> part if you are using Sponge! -->
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.10.0</version>
+                <extensions>true</extensions>
                 <configuration>
-                    <artifactSet>
-                        <includes>
-                            <include>net.wesjd:anvilgui</include>
-                            <include>org.browsit:MilkGUI</include>
-                        </includes>
-                    </artifactSet>
-                    <relocations>
-                        <relocation>
-                            <pattern>net.wesjd</pattern>
-                            <shadedPattern>net.wesjd</shadedPattern>
-                        </relocation>
-                    </relocations>
+                    <excludeArtifacts>
+                        <excludeArtifact>original*.jar</excludeArtifact>
+                    </excludeArtifacts>
+                    <checksums>all</checksums>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
-                        <phase>package</phase>
+                        <id>attach-sources</id>
                         <goals>
-                            <goal>shade</goal>
+                            <goal>jar</goal>
                         </goals>
-                        <configuration>
-                            <createDependencyReducedPom>false</createDependencyReducedPom>
-                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.10.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.6</version>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -110,8 +144,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.9.1-SNAPSHOT</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,19 @@
     <artifactId>MilkGUI</artifactId>
     <version>4.0.4</version>
 
+    <developers>
+        <developer>
+            <name>Browsit</name>
+        </developer>
+        <developer>
+            <name>PikaMug</name>
+        </developer>
+        <developer>
+            <name>Galen Nare</name>
+            <id>gnare</id>
+        </developer>
+    </developers>
+
     <licenses>
         <license>
             <name>MIT License</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.browsit</groupId>
     <artifactId>MilkGUI</artifactId>
-    <version>4.0.3</version>
+    <version>4.0.4</version>
 
     <licenses>
         <license>
@@ -24,8 +24,8 @@
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
         <repository>
-            <id>codemc-snapshots</id>
-            <url>https://repo.codemc.io/repository/maven-snapshots/</url>
+            <id>mvn-wesjd-net</id>
+            <url>https://mvn.wesjd.net/</url>
         </repository>
     </repositories>
 
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>net.wesjd</groupId>
             <artifactId>anvilgui</artifactId>
-            <version>1.10.10-SNAPSHOT</version>
+            <version>1.10.11-SNAPSHOT</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
# CHANGES

- Update `anvilgui` to `1.10.11-SNAPSHOT` (1.21.11) compatibility
- Update to new AnvilGUI maven repo as instructed in their GitHub readme
- Gitignore for standard Maven and IDEA ignorable files

I have tested shadowed inside my own plugin with the `xyz.jpenilla.run-paper` Gradle plugin.

If you have a separate test suite or plugin, let me know and I would be happy to share my results with those.
I can also provide screenshots of it working in my plugin if needed.

``` kotlin
    implementation("org.browsit:MilkGUI:4.0.4") {
        exclude group: 'org.bukkit', module: 'bukkit'
    }
```